### PR TITLE
Save the npz dtype as bytes

### DIFF
--- a/hexrd/imageseries/save.py
+++ b/hexrd/imageseries/save.py
@@ -229,7 +229,7 @@ class WriteFrameCache(Writer):
             pass
         arrd['shape'] = self._ims.shape
         arrd['nframes'] = len(self._ims)
-        arrd['dtype'] = str(self._ims.dtype)
+        arrd['dtype'] = str(self._ims.dtype).encode()
         arrd.update(self._process_meta())
         np.savez_compressed(self._cache, **arrd)
 


### PR DESCRIPTION
Currently, the npz reader expects the dtype to be in bytes ([here](https://github.com/joelvbernier/hexrd3/blob/2f841ffb7780a74af4f798c08aadd4a9160e5cbd/hexrd/imageseries/load/framecache.py#L68)).
The npz writer was not writing in bytes, which resulted in an
incompatibility between the two.

This commit modifies the writer to write out the npz dtype
in bytes so that the reader is able to read it correctly. It
fixes the incompatibility between the two.