### PR TITLE
Add missing del_eta to make_powder_rings

### DIFF
--- a/hexrd/instrument.py
+++ b/hexrd/instrument.py
@@ -1887,6 +1887,8 @@ class PlanarDetector(object):
                                 delta_tth, -delta_eta,
                                 0.0, 0.0]), (len(tth), 1)
                 )
+            # Convert to radians as is done below
+            del_eta = np.radians(delta_eta)
         else:
             # Okay, we have a PlaneData object
             try:


### PR DESCRIPTION
Most of the time, when a user would call `make_powder_rings()`,
they probably passed a PlaneData object. However, the function is
also designed to accept a list of two theta values. It appears,
though, that if you pass it a list of two theta values, it misses
the creation of del_eta that is normally done if a PlaneData object
is passed in.

This adds in the missing variable. The function seems to work properly
if this variable is included.